### PR TITLE
disable voting for own comments and articles

### DIFF
--- a/src/components/ArticleFooter.jsx
+++ b/src/components/ArticleFooter.jsx
@@ -1,9 +1,13 @@
+import { useContext } from "react";
 import { VOTE_TYPE_ARTICLE } from "../utils/constants";
 import VotingBar from "./VotingBar";
+import { LoggedInUserContext } from "../contexts/LoggedInUser";
 
 const ArticleFooter = ({ article, votingEnabled }) => {
+  const { loggedInUser } = useContext(LoggedInUserContext);
+
   const displayVotingArea = () =>
-    votingEnabled ? (
+    votingEnabled && loggedInUser?.username !== article.author ? (
       <VotingBar
         recordType={VOTE_TYPE_ARTICLE}
         recordId={article.article_id}

--- a/src/components/CommentFooter.jsx
+++ b/src/components/CommentFooter.jsx
@@ -47,15 +47,20 @@ const CommentFooter = ({ comment, updateCommentsList }) => {
     </div>
   );
 
+  const displayVotingArea = () =>
+    loggedInUser?.username !== comment.author ? (
+      <VotingBar
+        recordType={VOTE_TYPE_COMMENT}
+        recordId={comment.comment_id}
+        currentVotes={comment.votes}
+      />
+    ) : (
+      <>{comment.votes} votes</>
+    );
+
   return (
     <div className="flex justify-between">
-      <div>
-        <VotingBar
-          recordType={VOTE_TYPE_COMMENT}
-          recordId={comment.comment_id}
-          currentVotes={comment.votes}
-        />
-      </div>
+      <div>{displayVotingArea()}</div>
       {loggedInUser?.username === comment.author ? showDeleteButton() : null}
     </div>
   );


### PR DESCRIPTION
`VotingBar` is not shown if the article or comment user is the same as the logged in user. Instead it will just show the number of votes.